### PR TITLE
Simpler and more robust round to nearest multiple of step re. #121.

### DIFF
--- a/wappsto/modules/value.py
+++ b/wappsto/modules/value.py
@@ -346,10 +346,9 @@ class Value:
         """
         Ensure number value follows steps.
 
-        Converts values to decimal and ensures number step is always positive,
-        ensures that data value follows steps and removes exes 0's after
-        decimal point.
-
+        Round to the nearest multiple of number_step. Handles negative 
+        number_step.
+        
         Args:
             data_value: float value indicating current state of value.
 
@@ -358,18 +357,7 @@ class Value:
 
         """
         try:
-            data_value = decimal.Decimal(str(data_value))
-            number_step = abs(decimal.Decimal(str(self.number_step)))
-
-            result = data_value % number_step
-            if result < 0:
-                result += number_step
-            data_value = data_value - result
-
-            data_value = '{:f}'.format(data_value)
-            data_value = (data_value.rstrip('0').rstrip('.')
-                          if '.' in data_value else data_value)
-
+            data_value = round(data_value/self.number_step)*self.number_step
             return decimal.Decimal(data_value)
         except decimal.InvalidOperation as e:
             self.wapp_log.error("Invalid operation: {}".format(e))


### PR DESCRIPTION
Should fix #121. This is just a round-to-nearest-muliple of the step size. 

Essentially:

```py
def round2(x, step):
  return round(x/step)*step
   
import random
x = random.uniform(0, 100)
x
#38.72435205367791
round2(x, 0.1)
#38.7
round2(x, 0.2)
#38.800000000000004
round2(x, 0.03)
#38.73
round2(x, 12)
#36
round2(x, -12)
#36
```

The `38.800000000000004` will be taken care of by `decimal.Decimal` upon return.